### PR TITLE
Add expected-SR-conflicts + expected-RR-conflicts.

### DIFF
--- a/parser-tools-doc/parser-tools/parser-tools.scrbl
+++ b/parser-tools-doc/parser-tools/parser-tools.scrbl
@@ -495,7 +495,8 @@ be the right choice when using @racket[lexer] in other situations.
 @defmodule[parser-tools/yacc]
 
 @defform/subs[#:literals (grammar tokens start end precs src-pos
-                          suppress debug yacc-output prec)
+                          suppress expected-SR-conflicts expected-RR-conflicts
+                          debug yacc-output prec)
               (parser clause ...)
               ([clause (grammar (non-terminal-id 
                                  ((grammar-id ...) maybe-prec expr)
@@ -508,6 +509,8 @@ be the right choice when using @racket[lexer] in other situations.
                        (precs (assoc token-id ...) ...)
                        (src-pos)
                        (suppress)
+                       (expected-SR-conflicts)
+                       (expected-RR-conflicts)
                        (debug filename)
                        (yacc-output filename)]
                [maybe-prec code:blank
@@ -656,6 +659,18 @@ be the right choice when using @racket[lexer] in other situations.
       Causes the parser generator not to report shift/reduce or
       reduce/reduce conflicts.}
 
+      @item{@racket[(expected-SR-conflicts n)] @italic{OPTIONAL}
+
+      Causes the parser generator to expect exactly this many
+      shift/reduce conflicts.  @racket[suppress] overrides
+      this option.}
+
+      @item{@racket[(expected-RR-conflicts n)] @italic{OPTIONAL}
+
+      Causes the parser generator to expect exactly this many
+      reduce/reduce conflicts.  @racket[suppress] overrides
+      this option.}
+
     ]
 
     The result of a @racket[parser] expression with one @racket[start]
@@ -696,7 +711,8 @@ library provides a parser generator that is an alternative to that of
 @racketmodname[parser-tools/yacc].}
 
 @defform/subs[#:literals (grammar tokens start end precs src-pos
-                          suppress debug yacc-output prec)
+                          suppress expected-SR-conflicts expected-RR-conflicts
+                          debug yacc-output prec)
               (cfg-parser clause ...)
               ([clause (grammar (non-terminal-id 
                                  ((grammar-id ...) maybe-prec expr)
@@ -721,8 +737,9 @@ library provides a parser generator that is an alternative to that of
       a single non-terminal-id.}
                        
       @item{The @racket[cfg-parser] form does not support the @racket[precs], 
-             @racket[suppress], @racket[debug], or @racket[yacc-output]
-             options of @racket[parser].}
+             @racket[suppress], @racket[expected-SR-conflicts],
+             @racket[expected-RR-conflicts], @racket[debug],
+             or @racket[yacc-output] options of @racket[parser].}
    ]
 }                                            
                                             

--- a/parser-tools-lib/parser-tools/private-yacc/parser-builder.rkt
+++ b/parser-tools-lib/parser-tools/private-yacc/parser-builder.rkt
@@ -8,7 +8,7 @@
   (require-for-template mzscheme)
   
   (provide/contract
-   (build-parser (-> string? any/c any/c
+   (build-parser (-> string? any/c any/c any/c any/c
                      (listof identifier?)
                      (listof identifier?)
                      (listof identifier?)
@@ -74,9 +74,22 @@
             (let ((bind void) ... (tmp void) ...)
               (void bound ... ... term-group ... start ... end ... prec ...))))))
   (require mzlib/list "parser-actions.rkt")
-  (define (build-parser filename src-pos suppress input-terms start end assocs prods)
+  (define (build-parser filename
+                        src-pos
+                        suppress
+                        expected-SR-conflicts
+                        expected-RR-conflicts
+                        input-terms
+                        start
+                        end
+                        assocs
+                        prods)
     (let* ((grammar (parse-input input-terms start end assocs prods src-pos))
-           (table (build-table grammar filename suppress))
+           (table (build-table grammar
+                               filename
+                               suppress
+                               expected-SR-conflicts
+                               expected-RR-conflicts))
            (all-tokens (make-hash-table))
            (actions-code
             `(vector ,@(map prod-action (send grammar get-prods)))))

--- a/parser-tools-lib/parser-tools/yacc.rkt
+++ b/parser-tools-lib/parser-tools/yacc.rkt
@@ -42,12 +42,16 @@
              (end #f)
              (precs #f)
              (suppress #f)
+             (expected-SR-conflicts #f)
+             (expected-RR-conflicts #f)
              (grammar #f)
              (yacc-output #f))
          (for-each
           (lambda (arg)
             (syntax-case* arg (debug error tokens start end precs grammar
-                               suppress src-pos yacc-output)
+                               suppress src-pos yacc-output
+                               expected-SR-conflicts
+                               expected-RR-conflicts)
               (lambda (a b)
                 (eq? (syntax-e a) (syntax-e b)))
               ((debug filename)
@@ -64,6 +68,10 @@
                   (set! debug (syntax-e (syntax filename))))))
               ((suppress)
                (set! suppress #t))
+              ((expected-SR-conflicts n)
+               (set! expected-SR-conflicts (syntax-e (syntax n))))
+              ((expected-RR-conflicts n)
+               (set! expected-RR-conflicts (syntax-e (syntax n))))
               ((src-pos)
                (set! src-pos #t))
               ((error expression)
@@ -164,6 +172,8 @@
                        (build-parser (if debug debug "")
                                      src-pos
                                      suppress
+                                     expected-SR-conflicts
+                                     expected-RR-conflicts
                                      tokens
                                      start
                                      end


### PR DESCRIPTION
Add options for informing the yacc parser how many shift/reduce and
reduce/reduce conflicts to expect.

The options are inherited by cfg-parser but probably not useful there.

Fixes: https://github.com/racket/racket/issues/1669

`raco test .` passes.  I didn't find tests in private-yacc/ so I didn't add any.  Hope that's okay.